### PR TITLE
Reject non-canonical uint encodings during RLP decode

### DIFF
--- a/src/ethereum_rlp/rlp.py
+++ b/src/ethereum_rlp/rlp.py
@@ -267,6 +267,8 @@ def _deserialize_to_uint(
 ) -> Union[Uint, FixedUnsigned]:
     if not isinstance(decoded, bytes):
         raise DecodingError("invalid uint")
+    if len(decoded) > 0 and decoded[0] == 0:
+        raise DecodingError("non-canonical integer")
     try:
         return class_.from_be_bytes(decoded)
     except ValueError as e:

--- a/tests/test_rlp.py
+++ b/tests/test_rlp.py
@@ -353,6 +353,11 @@ def test_decode_to__uint_sequence() -> None:
         rlp.decode_to(Uint, b"\xc0")
 
 
+def test_decode_to__uint_non_canonical_zero() -> None:
+    with pytest.raises(DecodingError, match="non-canonical integer"):
+        rlp.decode_to(Uint, b"\x00")
+
+
 def test_decode_to__u8_invalid_len() -> None:
     with pytest.raises(DecodingError):
         rlp.decode_to(U8, b"\x82\x01\xff")


### PR DESCRIPTION
Summary\n- Reject non-canonical uint encodings with leading zero bytes during decode.\n- Add regression test for non-canonical zero.\n\nTests\n- ./.venv/bin/python -m pytest tests/test_rlp.py -k "non_canonical"\n\nFixes #10