### PR TITLE
Reject trailing bytes in single-object decode APIs

### DIFF
--- a/src/ethereum_rlp/rlp.py
+++ b/src/ethereum_rlp/rlp.py
@@ -529,7 +529,8 @@ def decode_item_length(encoded_data: Bytes) -> int:
         decoded_data_length = first_rlp_byte - 0xC0
     # This occurs only when the raw_data is a sequence of objects and
     # doesn't fall into the above cases.
-    elif first_rlp_byte <= 0xFF:
+    else:
+        assert first_rlp_byte <= 0xFF
         length_length = first_rlp_byte - 0xF7
         if length_length >= len(encoded_data):
             raise DecodingError("truncated")

--- a/src/ethereum_rlp/rlp.py
+++ b/src/ethereum_rlp/rlp.py
@@ -148,11 +148,6 @@ def decode(encoded_data: Bytes) -> Simple:
     if len(encoded_data) <= 0:
         raise DecodingError("Cannot decode empty bytestring")
 
-    # `decode` is a single-object API. If the first encoded item is shorter
-    # than the full input buffer, trailing bytes are present.
-    if decode_item_length(encoded_data) < len(encoded_data):
-        raise DecodingError("input contains more than one value")
-
     if encoded_data[0] <= 0xBF:
         # This means that the raw data is of type bytes
         return decode_to_bytes(encoded_data)
@@ -402,6 +397,8 @@ def decode_to_bytes(encoded_bytes: Bytes) -> Bytes:
             raise DecodingError("negative length")
         if len_raw_data >= len(encoded_bytes):
             raise DecodingError("truncated")
+        if 1 + len_raw_data < len(encoded_bytes):
+            raise DecodingError("input contains more than one value")
         raw_data = encoded_bytes[1 : 1 + len_raw_data]
         if len_raw_data == 1 and raw_data[0] < 0x80:
             raise DecodingError
@@ -422,6 +419,8 @@ def decode_to_bytes(encoded_bytes: Bytes) -> Bytes:
         decoded_data_end_idx = decoded_data_start_idx + int(len_decoded_data)
         if decoded_data_end_idx - 1 >= len(encoded_bytes):
             raise DecodingError
+        if decoded_data_end_idx < len(encoded_bytes):
+            raise DecodingError("input contains more than one value")
         return encoded_bytes[decoded_data_start_idx:decoded_data_end_idx]
 
 
@@ -434,6 +433,8 @@ def decode_to_sequence(encoded_sequence: Bytes) -> Sequence[Simple]:
         len_joined_encodings = encoded_sequence[0] - 0xC0
         if len_joined_encodings >= len(encoded_sequence):
             raise DecodingError
+        if 1 + len_joined_encodings < len(encoded_sequence):
+            raise DecodingError("input contains more than one value")
         joined_encodings = encoded_sequence[1 : 1 + len_joined_encodings]
     else:
         joined_encodings_start_idx = 1 + encoded_sequence[0] - 0xF7
@@ -451,6 +452,8 @@ def decode_to_sequence(encoded_sequence: Bytes) -> Sequence[Simple]:
         )
         if joined_encodings_end_idx - 1 >= len(encoded_sequence):
             raise DecodingError
+        if joined_encodings_end_idx < len(encoded_sequence):
+            raise DecodingError("input contains more than one value")
         joined_encodings = encoded_sequence[
             joined_encodings_start_idx:joined_encodings_end_idx
         ]

--- a/src/ethereum_rlp/rlp.py
+++ b/src/ethereum_rlp/rlp.py
@@ -398,7 +398,7 @@ def decode_to_bytes(encoded_bytes: Bytes) -> Bytes:
         if len_raw_data >= len(encoded_bytes):
             raise DecodingError("truncated")
         if 1 + len_raw_data < len(encoded_bytes):
-            raise DecodingError("input contains more than one value")
+            raise DecodingError("trailing bytes")
         raw_data = encoded_bytes[1 : 1 + len_raw_data]
         if len_raw_data == 1 and raw_data[0] < 0x80:
             raise DecodingError
@@ -408,7 +408,7 @@ def decode_to_bytes(encoded_bytes: Bytes) -> Bytes:
         # starts from.
         decoded_data_start_idx = 1 + encoded_bytes[0] - 0xB7
         if decoded_data_start_idx - 1 >= len(encoded_bytes):
-            raise DecodingError
+            raise DecodingError("truncated")
         if encoded_bytes[1] == 0:
             raise DecodingError
         len_decoded_data = int(
@@ -418,9 +418,9 @@ def decode_to_bytes(encoded_bytes: Bytes) -> Bytes:
             raise DecodingError
         decoded_data_end_idx = decoded_data_start_idx + int(len_decoded_data)
         if decoded_data_end_idx - 1 >= len(encoded_bytes):
-            raise DecodingError
+            raise DecodingError("truncated")
         if decoded_data_end_idx < len(encoded_bytes):
-            raise DecodingError("input contains more than one value")
+            raise DecodingError("trailing bytes")
         return encoded_bytes[decoded_data_start_idx:decoded_data_end_idx]
 
 
@@ -432,14 +432,14 @@ def decode_to_sequence(encoded_sequence: Bytes) -> Sequence[Simple]:
     if encoded_sequence[0] <= 0xF7:
         len_joined_encodings = encoded_sequence[0] - 0xC0
         if len_joined_encodings >= len(encoded_sequence):
-            raise DecodingError
+            raise DecodingError("truncated")
         if 1 + len_joined_encodings < len(encoded_sequence):
-            raise DecodingError("input contains more than one value")
+            raise DecodingError("trailing bytes")
         joined_encodings = encoded_sequence[1 : 1 + len_joined_encodings]
     else:
         joined_encodings_start_idx = 1 + encoded_sequence[0] - 0xF7
         if joined_encodings_start_idx - 1 >= len(encoded_sequence):
-            raise DecodingError
+            raise DecodingError("truncated")
         if encoded_sequence[1] == 0:
             raise DecodingError
         len_joined_encodings = int(
@@ -451,9 +451,9 @@ def decode_to_sequence(encoded_sequence: Bytes) -> Sequence[Simple]:
             joined_encodings_start_idx + len_joined_encodings
         )
         if joined_encodings_end_idx - 1 >= len(encoded_sequence):
-            raise DecodingError
+            raise DecodingError("truncated")
         if joined_encodings_end_idx < len(encoded_sequence):
-            raise DecodingError("input contains more than one value")
+            raise DecodingError("trailing bytes")
         joined_encodings = encoded_sequence[
             joined_encodings_start_idx:joined_encodings_end_idx
         ]
@@ -474,7 +474,7 @@ def decode_joined_encodings(joined_encodings: Bytes) -> Sequence[Simple]:
             joined_encodings[item_start_idx:]
         )
         if item_start_idx + encoded_item_length - 1 >= len(joined_encodings):
-            raise DecodingError
+            raise DecodingError("truncated")
         encoded_item = joined_encodings[
             item_start_idx : item_start_idx + encoded_item_length
         ]
@@ -517,7 +517,7 @@ def decode_item_length(encoded_data: Bytes) -> int:
     elif first_rlp_byte <= 0xBF:
         length_length = first_rlp_byte - 0xB7
         if length_length >= len(encoded_data):
-            raise DecodingError
+            raise DecodingError("truncated")
         if encoded_data[1] == 0:
             raise DecodingError
         decoded_data_length = int(
@@ -532,7 +532,7 @@ def decode_item_length(encoded_data: Bytes) -> int:
     elif first_rlp_byte <= 0xFF:
         length_length = first_rlp_byte - 0xF7
         if length_length >= len(encoded_data):
-            raise DecodingError
+            raise DecodingError("truncated")
         if encoded_data[1] == 0:
             raise DecodingError
         decoded_data_length = int(

--- a/src/ethereum_rlp/rlp.py
+++ b/src/ethereum_rlp/rlp.py
@@ -148,6 +148,11 @@ def decode(encoded_data: Bytes) -> Simple:
     if len(encoded_data) <= 0:
         raise DecodingError("Cannot decode empty bytestring")
 
+    # `decode` is a single-object API. If the first encoded item is shorter
+    # than the full input buffer, trailing bytes are present.
+    if decode_item_length(encoded_data) < len(encoded_data):
+        raise DecodingError("input contains more than one value")
+
     if encoded_data[0] <= 0xBF:
         # This means that the raw data is of type bytes
         return decode_to_bytes(encoded_data)

--- a/tests/test_rlp.py
+++ b/tests/test_rlp.py
@@ -697,6 +697,22 @@ def test_decode__failure_empty_bytes() -> None:
         rlp.decode(b"")
 
 
+def test_decode__rejects_trailing_bytes_after_string() -> None:
+    with pytest.raises(DecodingError):
+        rlp.decode(b"\x80\x00")
+
+
+def test_decode__rejects_trailing_bytes_after_list() -> None:
+    with pytest.raises(DecodingError):
+        rlp.decode(b"\xc0\x00")
+
+
+def test_decode_to__rejects_trailing_bytes() -> None:
+    encoded = rlp.encode(Stuff(toggle=True, number=Uint(3), sequence=[]))
+    with pytest.raises(DecodingError):
+        rlp.decode_to(Stuff, encoded + b"\x00")
+
+
 def test_round_trip_encoding_and_decoding() -> None:
     test_cases: List[Extended] = [
         b"",

--- a/tests/test_rlp.py
+++ b/tests/test_rlp.py
@@ -296,13 +296,13 @@ def test_decode_to_bytes__long_out_of_bounds() -> None:
 
 
 def test_decode_to_bytes__rejects_trailing_bytes() -> None:
-    with pytest.raises(DecodingError):
+    with pytest.raises(DecodingError, match="trailing"):
         rlp.decode_to_bytes(b"\x80\x00")
 
 
 def test_decode_to_bytes__rejects_trailing_bytes_long() -> None:
     encoded = b"\xB8\x38" + (b"\x00" * 0x38)
-    with pytest.raises(DecodingError):
+    with pytest.raises(DecodingError, match="trailing"):
         rlp.decode_to_bytes(encoded + b"\x00")
 
 
@@ -665,13 +665,13 @@ def test_decode_to_sequence__out_of_bounds_item() -> None:
 
 
 def test_decode_to_sequence__rejects_trailing_bytes() -> None:
-    with pytest.raises(DecodingError):
+    with pytest.raises(DecodingError, match="trailing"):
         rlp.decode_to_sequence(b"\xc0\x00")
 
 
 def test_decode_to_sequence__rejects_trailing_bytes_long() -> None:
     encoded = b"\xF8\x38" + (b"\x80" * 0x38)
-    with pytest.raises(DecodingError):
+    with pytest.raises(DecodingError, match="trailing"):
         rlp.decode_to_sequence(encoded + b"\x00")
 
 
@@ -720,18 +720,18 @@ def test_decode__failure_empty_bytes() -> None:
 
 
 def test_decode__rejects_trailing_bytes_after_string() -> None:
-    with pytest.raises(DecodingError):
+    with pytest.raises(DecodingError, match="trailing"):
         rlp.decode(b"\x80\x00")
 
 
 def test_decode__rejects_trailing_bytes_after_list() -> None:
-    with pytest.raises(DecodingError):
+    with pytest.raises(DecodingError, match="trailing"):
         rlp.decode(b"\xc0\x00")
 
 
 def test_decode_to__rejects_trailing_bytes() -> None:
     encoded = rlp.encode(Stuff(toggle=True, number=Uint(3), sequence=[]))
-    with pytest.raises(DecodingError):
+    with pytest.raises(DecodingError, match="trailing"):
         rlp.decode_to(Stuff, encoded + b"\x00")
 
 

--- a/tests/test_rlp.py
+++ b/tests/test_rlp.py
@@ -300,6 +300,12 @@ def test_decode_to_bytes__rejects_trailing_bytes() -> None:
         rlp.decode_to_bytes(b"\x80\x00")
 
 
+def test_decode_to_bytes__rejects_trailing_bytes_long() -> None:
+    encoded = b"\xB8\x38" + (b"\x00" * 0x38)
+    with pytest.raises(DecodingError):
+        rlp.decode_to_bytes(encoded + b"\x00")
+
+
 @pytest.mark.parametrize(
     "encoded_bytes",
     [b"~\xbc\xc5^\xbe\xff", b"Q59:\xba\xf4\xda\x05\xb7"],
@@ -661,6 +667,12 @@ def test_decode_to_sequence__out_of_bounds_item() -> None:
 def test_decode_to_sequence__rejects_trailing_bytes() -> None:
     with pytest.raises(DecodingError):
         rlp.decode_to_sequence(b"\xc0\x00")
+
+
+def test_decode_to_sequence__rejects_trailing_bytes_long() -> None:
+    encoded = b"\xF8\x38" + (b"\x80" * 0x38)
+    with pytest.raises(DecodingError):
+        rlp.decode_to_sequence(encoded + b"\x00")
 
 
 def test_decode_to_sequence__out_of_bounds() -> None:

--- a/tests/test_rlp.py
+++ b/tests/test_rlp.py
@@ -295,6 +295,11 @@ def test_decode_to_bytes__long_out_of_bounds() -> None:
         rlp.decode_to_bytes(input)
 
 
+def test_decode_to_bytes__rejects_trailing_bytes() -> None:
+    with pytest.raises(DecodingError):
+        rlp.decode_to_bytes(b"\x80\x00")
+
+
 @pytest.mark.parametrize(
     "encoded_bytes",
     [b"~\xbc\xc5^\xbe\xff", b"Q59:\xba\xf4\xda\x05\xb7"],
@@ -651,6 +656,11 @@ def test_decode_to_sequence__nested() -> None:
 def test_decode_to_sequence__out_of_bounds_item() -> None:
     with pytest.raises(DecodingError):
         rlp.decode_to_sequence(b"\xc1\x81")
+
+
+def test_decode_to_sequence__rejects_trailing_bytes() -> None:
+    with pytest.raises(DecodingError):
+        rlp.decode_to_sequence(b"\xc0\x00")
 
 
 def test_decode_to_sequence__out_of_bounds() -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ commands =
         --cov-fail-under=100 \
         -n auto --maxprocesses 5 \
         --cov=ethereum_rlp --cov-report=term --cov-report "xml:{toxworkdir}/coverage.xml" \
+        --cov-branch \
         --basetemp="{temp_dir}/pytest"
 
 [testenv:pypy3]


### PR DESCRIPTION
Closes #13

## Summary

This changes single-object decode behavior to reject trailing bytes:

- `decode()` now raises `DecodingError` when input contains more than one RLP value.
- `decode_to()` inherits this via `decode()`.

Concretely, inputs like `rlp(value) || trailing_bytes` are no longer accepted by these APIs.

## What changed

- `src/ethereum_rlp/rlp.py`
  - Added a full-consumption check in `decode()` using `decode_item_length(...)`.
  - If the first encoded item is shorter than the provided buffer, raise:
    - `DecodingError("input contains more than one value")`.

- `tests/test_rlp.py`
  - Added regression tests:
    - `decode(b"\x80\x00")` rejects
    - `decode(b"\xc0\x00")` rejects
    - `decode_to(Stuff, encoded + b"\x00")` rejects

## Scope / Nuance

This PR intentionally targets **single-object APIs** (`decode` / `decode_to`).

It does **not** change direct helper behavior for:
- `decode_to_bytes()`
- `decode_to_sequence()`

Those can be addressed separately if stricter helper semantics are desired.
